### PR TITLE
Added twig-bundle as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/security-bundle": "^4.0",
         "symfony/serializer-pack": "*",
         "symfony/swiftmailer-bundle": "^3.1",
+        "symfony/twig-bundle": "^4.0",
         "symfony/validator": "^4.0",
         "symfony/web-link": "^4.0",
         "symfony/webpack-encore-pack": "*",


### PR DESCRIPTION
It's a fix for #5

The exact problem it solves:

1. Create a project from `website-skeleton`

```
composer create-project symfony/website-skeleton my-project
```

2. Remove `vendor`

3. `APP_ENV=prod composer install --no-dev`

Expected: all good

Actual:

```
Generating autoload files
ocramius/package-versions:  Generating version class...
ocramius/package-versions: ...done generating version class
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  PHP Fatal error:  Uncaught Error: Class 'Symfony\Bundle\TwigBundle\TwigBundle' not found in /tmp/my-project/src/Kernel.php:33
```