### PR TITLE
Simplify dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,10 @@
         "symfony/yaml": "^3.3"
     },
     "require-dev": {
-        "symfony/browser-kit": "^3.3",
-        "symfony/css-selector": "^3.3",
         "symfony/debug-pack": "*",
         "symfony/dotenv": "^3.3",
         "symfony/maker-bundle": "^1.0",
-        "symfony/phpunit-bridge": "^3.3",
+        "symfony/test-pack": "^1.0",
         "symfony/web-server-bundle": "^3.3"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "symfony/dotenv": "^3.3",
         "symfony/maker-bundle": "^1.0",
         "symfony/phpunit-bridge": "^3.3",
-        "symfony/profiler-pack": "*",
         "symfony/web-server-bundle": "^3.3"
     },
     "config": {


### PR DESCRIPTION
The profiler pack is included in the debug pack, let's remove it.

The skeleton is taken as model to require packages quite often let's use the test pack here, WDYT?