### PR TITLE
Remove Webpack Encore by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "symfony/twig-bundle": "^3.4",
         "symfony/validator": "^3.4",
         "symfony/web-link": "^3.4",
-        "symfony/webpack-encore-pack": "*",
         "symfony/yaml": "^3.4"
     },
     "require-dev": {


### PR DESCRIPTION
See https://github.com/symfony/recipes/pull/410/files#diff-4b4cf4dee8f798bf810b271aeaa66aa1

Thanks to this (which I approved), anyone using `symfony-skeleton` will now immediately get an error if they use the `asset()` function, until they build their Encore assets:

> Asset manifest file "/.../public/build/manifest.json" does not exist.

I know the purpose of this skeleton is to be more of a "kitchen" sink. But I think we can make Encore an optional feature that users can then install. The alternative would be to make its recipe a little "weaker" by commenting out the `json_manifest_path` line. But then, when users begin using Encore, they will need to go find this file and uncomment this line. Asking them int `composer require encore` seems easier.
