### PR TITLE
List symfony/translation explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/security-bundle": "*",
         "symfony/serializer-pack": "*",
         "symfony/swiftmailer-bundle": "^3.1",
+        "symfony/translation": "*",
         "symfony/twig-bundle": "*",
         "symfony/validator": "*",
         "symfony/web-link": "*",


### PR DESCRIPTION
I just figured out that `symfony/translation` is already installed on 3.4 up to  4.1 but not on 4.2 anymore, the reason being that `symfony/validator` doesn't require it anymore in master.
Let's make it explicit.