### PR TITLE
Move dotenv to "require"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "sensio/framework-extra-bundle": "^5.1",
         "symfony/asset": "*",
         "symfony/console": "*",
+        "symfony/dotenv": "*",
         "symfony/expression-language": "*",
         "symfony/flex": "^1.1",
         "symfony/form": "*",
@@ -28,7 +29,6 @@
     },
     "require-dev": {
         "symfony/debug-pack": "*",
-        "symfony/dotenv": "*",
         "symfony/maker-bundle": "^1.0",
         "symfony/profiler-pack": "*",
         "symfony/test-pack": "*",


### PR DESCRIPTION
This doesn't hurt anything and should ease using .env files without issues.