### PR TITLE
Don't install the WebServerBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "symfony/debug-pack": "*",
         "symfony/maker-bundle": "^1.0",
         "symfony/profiler-pack": "*",
-        "symfony/test-pack": "*",
-        "symfony/web-server-bundle": "*"
+        "symfony/test-pack": "*"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
We're starting to not recommend using the WebServerBundle in favor of the [Symfony Local Web Server](https://symfony.com/doc/current/setup/symfony_server.html) (see https://github.com/symfony/symfony-docs/pull/11567/files) so I guess we can remove this dependency.