### PR TITLE
Prepare for stable release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "type": "project",
     "license": "MIT",
     "description": "A skeleton to start a new Symfony website",
-    "minimum-stability": "dev",
     "require": {
         "php": "^7.1.3",
         "ext-ctype": "*",


### PR DESCRIPTION
Same as https://github.com/symfony/skeleton/pull/178

To be tagged as `4.4.99` once merged, then into branch 5.0 for `5.0.99` - but ignored when merging branch 5.0 into master.